### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,11 @@
+
+import os
+import sys
+
 from setuptools import find_packages, setup
+
+helpDir = os.path.join("cdd", "help_docs")
+helpFiles = [os.path.join(helpDir, f) for f in os.listdir(helpDir)]
 
 setup(
     name = 'cdd-api',
@@ -8,6 +15,7 @@ setup(
     author_email = 'chris.lowden@workflowinformatics.com',
     packages = find_packages(include=["cdd"]),
     include_package_data=True,
+    data_files=[("help_docs", helpFiles)],
     install_requires = [
                         'numpy',
                         'gooey',


### PR DESCRIPTION
Explicitly set help documentation data files to include in package installation. Windows installs were previously not installing the help documentation from the manifest file.